### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add this line to your application's Gemfile:
 # for fluentd
 gem install fluent-plugin-parser_cef
 
-# for td-agent2
+# for td-agent3
 td-agent-gem install fluent-plugin-parser_cef
 ```
 

--- a/fluent-plugin-parser_cef.gemspec
+++ b/fluent-plugin-parser_cef.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = "~> 2.1"
 
-  spec.add_runtime_dependency "fluentd", ">= 0.12", "< 0.14"
+  spec.add_runtime_dependency "fluentd", ">= 0.14.0", "< 2"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/spec/fluent/plugin/parser_cef_spec.rb
+++ b/spec/fluent/plugin/parser_cef_spec.rb
@@ -2,8 +2,9 @@
 
 require 'fluent/plugin/parser_cef'
 require 'fluent/test'
+require 'fluent/test/driver/parser'
 
-RSpec.describe Fluent::TextParser::CommonEventFormatParser do
+RSpec.describe Fluent::Plugin::CommonEventFormatParser do
 
   DEFAULT_CONFIGURE = %[
     log_format  syslog
@@ -13,8 +14,8 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
     cef_keyfilename  'config/cef_version_0_keys.yaml'
     output_raw_field  false
   ]
-  def create_driver(conf=DEFAULT_CONFIGURE, tag='test')
-    Fluent::Test::ParserTestDriver.new(Fluent::TextParser::CommonEventFormatParser, tag).configure(conf)
+  def create_driver(conf=DEFAULT_CONFIGURE)
+    Fluent::Test::Driver::Parser.new(Fluent::Plugin::CommonEventFormatParser).configure(conf)
   end
 
   before :all do
@@ -30,47 +31,71 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
     context "text == nil" do
       let (:text) { nil }
       subject do
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [nil, nil] }
     end
     context "text is empty string" do
       let (:text) { "" }
       subject do
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [nil, nil] }
     end
     context "text is not syslog format nor CEF" do
       let (:text) { "December 12 10:00:00 hostname tag message" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
-        @test_driver.parse(text)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
-      it { is_expected.to contain_exactly(be_an(Integer), { "raw" => "December 12 10:00:00 hostname tag message" }) }
+      it { is_expected.to contain_exactly(be_an(Fluent::EventTime), { "raw" => "December 12 10:00:00 hostname tag message" }) }
     end
     context "text is not in syslog format but is CEF" do
       let (:text) { "December 12 10:00:00 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|cs1=test" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
-        @test_driver.parse(text)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
-      it { is_expected.to contain_exactly(be_an(Integer), { "raw" => "December 12 10:00:00 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|cs1=test" }) }
+      it { is_expected.to contain_exactly(be_an(Fluent::EventTime), { "raw" => "December 12 10:00:00 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|cs1=test" }) }
     end
     context "text is syslog format but not CEF" do
       let (:text) { "Dec 12 10:11:12 hostname tag message" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
-        @test_driver.parse(text)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
-      it { is_expected.to contain_exactly(be_an(Integer), { "raw" => "Dec 12 10:11:12 hostname tag message" }) }
+      it { is_expected.to contain_exactly(be_an(Fluent::EventTime), { "raw" => "Dec 12 10:11:12 hostname tag message" }) }
     end
     context "text is syslog format and CEF (CEF Extension field is empty)" do
       let (:text) { "Dec  2 03:17:06 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("Dec  2 03:17:06").to_i
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {
@@ -88,9 +113,13 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
     context "text is syslog format and CEF (there is only one valid key in the CEF Extension field), Strict mode on" do
       let (:text) { "Dec  2 03:17:06 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|cs1=test" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("Dec  2 03:17:06").to_i
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {
@@ -112,10 +141,14 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
       ]}
       let (:text) { "Dec  2 03:17:06 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|foo=bar" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("Dec  2 03:17:06").to_i
         @test_driver = create_driver(config)
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {
@@ -137,10 +170,14 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
       ]}
       let (:text) { "2014-06-07T18:55:09.019283+09:00 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|foo=bar" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("2014-06-07T18:55:09.019283+09:00").to_i
         @test_driver = create_driver(config)
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {
@@ -161,10 +198,14 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
       ]}
       let (:text) { "2014-06-07T18:55:09.019283+03:00 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|foo=bar" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("2014-06-07T18:55:09.019283+03:00").to_i
         @test_driver = create_driver(config)
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {
@@ -185,10 +226,14 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
       ]}
       let (:text) { "2014-06-07T18:55:09.019283Z hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|foo=bar" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("2014-06-07T18:55:09.019283Z").to_i
         @test_driver = create_driver(config)
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {
@@ -209,10 +254,14 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
       ]}
       let (:text) { "Dec  2 03:17:06 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|cs1=test" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("Dec  2 03:17:06 +04:00").to_i
         @test_driver = create_driver(config)
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {
@@ -235,10 +284,14 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
       ]}
       let (:text) { "2013-07-24T12:34:56.923984+03:30 hostname tag CEF:0|Vendor|Product|Version|ID|Name|Severity|cs1=test" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("2013-07-24T12:34:56.923984+03:30").to_i
         @test_driver = create_driver(config)
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {
@@ -260,14 +313,18 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
       ]}
       let (:text) { "Dec  2 03:17:06 hostname tag ***CEF:0|Vendor|Product|Version|ID|Name|Severity|cs1=test" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("Dec  2 03:17:06 -07:00").to_i
         @test_driver = create_driver(config)
         text.setbyte(29, 0xef)
         text.setbyte(30, 0xbb)
         text.setbyte(31, 0xbf)
         text.force_encoding("ascii-8bit")
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {
@@ -289,11 +346,14 @@ RSpec.describe Fluent::TextParser::CommonEventFormatParser do
       ]}
       let (:text) { "Feb 19 00:35:11 hogehuga CEF:0|Vendor|Product|Version|ID|Name|Severity|src=192.168.1.1 spt=60000 dst=172.16.100.100 dpt=80 msg=\xe3\x2e\x2e\x2e" }
       subject do
-        allow(Fluent::Engine).to receive(:now).and_return(Time.now.to_i)
+        allow(Fluent::Engine).to receive(:now).and_return(Fluent::EventTime.now)
         @timestamp = Time.parse("Feb 19 00:35:11 +09:00").to_i
         @test_driver = create_driver(config)
-        text.force_encoding("ascii-8bit")
-        @test_driver.parse(text)
+        parsed = nil
+        @test_driver.instance.parse(text) do |time, record|
+          parsed = [time, record]
+        end
+        parsed
       end
       it { is_expected.to eq [
         @timestamp, {


### PR DESCRIPTION
I've tried to migrate to use v0.14 Parser Plugin API.
This PR contains major update change and also includes in breaking changes.

The following API won't support in v0.14:

```ruby
@parser.parse(text)
```

The following API shall support in v0.14:

```ruby
@parser.parse(text) do |time, record|
  # do somthing
end
```

If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.