### PR TITLE
fix: allow all ruby versions greater than 2.1

### DIFF
--- a/fluent-plugin-parser_cef.gemspec
+++ b/fluent-plugin-parser_cef.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.1"
+  spec.required_ruby_version = ">= 2.1"
 
   spec.add_runtime_dependency "fluentd", ">= 0.14.0", "< 2"
 


### PR DESCRIPTION
remove the version pinning to 2.1, README states that starting from tag 1.0.0 all ruby versions >= 2.1 are supported.